### PR TITLE
[feat] 라우터 설정 및 라우터 별 폴더, 빈 페이지 생성

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,8 @@
+import { RouterProvider } from "react-router-dom";
+
+import { router } from "./Router";
+
 function App() {
-  return <div className="text-4xl">Hello TheJulge</div>;
+  return <RouterProvider router={router} />;
 }
 export default App;

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,0 +1,103 @@
+import { lazy } from "react";
+
+import { createBrowserRouter, Outlet, RouteObject } from "react-router-dom";
+
+import { ROUTES } from "./constants/router";
+
+const SignupPage = lazy(() => import("@/pages/SignupPage"));
+const SigninPage = lazy(() => import("@/pages/SigninPage"));
+
+const ProfilePage = lazy(() => import("@/pages/ProfilePage"));
+const ProfileRegisterPage = lazy(() => import("@/pages/ProfileRegisterPage"));
+const ProfileEditPage = lazy(() => import("@/pages/ProfileEditPage"));
+
+const ShopPage = lazy(() => import("@/pages/ShopPage"));
+const ShopRegisterPage = lazy(() => import("@/pages/ShopRegisterPage"));
+const ShopEditPage = lazy(() => import("@/pages/ShopEditPage"));
+
+const NoticeListPage = lazy(() => import("@/pages/NoticeListPage"));
+const NoticeRegisterPage = lazy(() => import("@/pages/NoticeRegisterPage"));
+const NoticeEditPage = lazy(() => import("@/pages/NoticeEditPage"));
+const NoticeEmployerPage = lazy(() => import("@/pages/NoticeEmployerPage"));
+const NoticeEmployeePage = lazy(() => import("@/pages/NoticeEmployeePage"));
+
+const authRoutes: RouteObject[] = [
+  {
+    path: ROUTES.AUTH.SIGNUP,
+    Component: SignupPage,
+  },
+  {
+    path: ROUTES.AUTH.SIGNIN,
+    Component: SigninPage,
+  },
+];
+
+const shopRoutes: RouteObject[] = [
+  {
+    path: ROUTES.SHOP.ROOT,
+    Component: ShopPage,
+  },
+  {
+    path: ROUTES.SHOP.REGISTER,
+    Component: ShopRegisterPage,
+  },
+  {
+    path: ROUTES.SHOP.EDIT,
+    Component: ShopEditPage,
+  },
+];
+
+const profileRoutes: RouteObject[] = [
+  {
+    path: ROUTES.PROFILE.ROOT,
+    Component: ProfilePage,
+  },
+  {
+    path: ROUTES.PROFILE.REGISTER,
+    Component: ProfileRegisterPage,
+  },
+  {
+    path: ROUTES.PROFILE.EDIT,
+    Component: ProfileEditPage,
+  },
+];
+
+const noticeRoutes: RouteObject[] = [
+  {
+    path: ROUTES.NOTICE.ROOT,
+    Component: NoticeListPage,
+  },
+  {
+    path: ROUTES.NOTICE.REGISTER,
+    Component: NoticeRegisterPage,
+  },
+  {
+    path: ROUTES.NOTICE.EDIT,
+    Component: NoticeEditPage,
+  },
+  {
+    path: ROUTES.NOTICE.NOTICE_ID.EMPLOYER,
+    Component: NoticeEmployerPage,
+  },
+  {
+    path: ROUTES.NOTICE.NOTICE_ID.EMPLOYEE,
+    Component: NoticeEmployeePage,
+  },
+];
+
+const appRoutes: RouteObject[] = [
+  ...shopRoutes,
+  ...profileRoutes,
+  ...noticeRoutes,
+];
+
+export const router = createBrowserRouter([
+  {
+    Component: Outlet,
+    children: authRoutes,
+  },
+  {
+    Component: Outlet,
+    children: appRoutes,
+  },
+]);

--- a/src/constants/router.ts
+++ b/src/constants/router.ts
@@ -1,0 +1,27 @@
+const ROUTES = {
+  AUTH: {
+    SIGNUP: "/signup",
+    SIGNIN: "/signin",
+  },
+  SHOP: {
+    ROOT: "/shop",
+    REGISTER: "/shop/register",
+    EDIT: "/shop/edit",
+  },
+  PROFILE: {
+    ROOT: "/profile",
+    REGISTER: "/profile/register",
+    EDIT: "/profile/edit",
+  },
+  NOTICE: {
+    ROOT: "/",
+    REGISTER: "/notice/register",
+    EDIT: "/notice/edit",
+    NOTICE_ID: {
+      EMPLOYER: `/notice/:noticeId/employer`,
+      EMPLOYEE: `/notice/:noticeId/employee`,
+    },
+  },
+} as const;
+
+export { ROUTES };

--- a/src/pages/NoticeEditPage.tsx
+++ b/src/pages/NoticeEditPage.tsx
@@ -1,0 +1,3 @@
+export default function NoticeEditPage() {
+  return <div>NoticeEditPage</div>;
+}

--- a/src/pages/NoticeEmployeePage.tsx
+++ b/src/pages/NoticeEmployeePage.tsx
@@ -1,0 +1,3 @@
+export default function NoticeEmployeePage() {
+  return <div>NoticeEmployeePage</div>;
+}

--- a/src/pages/NoticeEmployerPage.tsx
+++ b/src/pages/NoticeEmployerPage.tsx
@@ -1,0 +1,3 @@
+export default function NoticeEmployerPage() {
+  return <div>NoticeEmployerPage</div>;
+}

--- a/src/pages/NoticeListPage.tsx
+++ b/src/pages/NoticeListPage.tsx
@@ -1,0 +1,3 @@
+export default function NoticeListPage() {
+  return <div>NoticeListPage</div>;
+}

--- a/src/pages/NoticeRegisterPage.tsx
+++ b/src/pages/NoticeRegisterPage.tsx
@@ -1,0 +1,3 @@
+export default function NoticeRegisterPage() {
+  return <div>NoticeRegisterPage</div>;
+}

--- a/src/pages/ProfileEditPage.tsx
+++ b/src/pages/ProfileEditPage.tsx
@@ -1,0 +1,3 @@
+export default function ProfileEditPage() {
+  return <div>ProfileEditPage</div>;
+}

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,0 +1,3 @@
+export default function ProfilePage() {
+  return <div>ProfilePage</div>;
+}

--- a/src/pages/ProfileRegisterPage.tsx
+++ b/src/pages/ProfileRegisterPage.tsx
@@ -1,0 +1,3 @@
+export default function ProfileRegisterPage() {
+  return <div>ProfileRegisterPage</div>;
+}

--- a/src/pages/ShopEditPage.tsx
+++ b/src/pages/ShopEditPage.tsx
@@ -1,0 +1,3 @@
+export default function ShopEditPage() {
+  return <div>ShopEditPage</div>;
+}

--- a/src/pages/ShopPage.tsx
+++ b/src/pages/ShopPage.tsx
@@ -1,0 +1,3 @@
+export default function ShopPage() {
+  return <div>ShopPage</div>;
+}

--- a/src/pages/ShopRegisterPage.tsx
+++ b/src/pages/ShopRegisterPage.tsx
@@ -1,0 +1,3 @@
+export default function ShopRegisterPage() {
+  return <div>ShopRegisterPage</div>;
+}

--- a/src/pages/SigninPage.tsx
+++ b/src/pages/SigninPage.tsx
@@ -1,0 +1,3 @@
+export default function SigninPage() {
+  return <div>SigninPage</div>;
+}

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,0 +1,3 @@
+export default function SignupPage() {
+  return <div>SignupPage</div>;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,10 +8,12 @@ import tsPathsConfig from "./tsconfig.paths.json";
 
 const aliases = Object.entries(tsPathsConfig.compilerOptions.paths).map(
   ([key, [value]]) => ({
-    find: key.replace("*", ""),
+    find: key.replace("/*", ""),
     replacement: path.resolve(__dirname, value.replace("/*", "")),
   }),
 );
+
+console.log(aliases);
 
 //* https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

Closes #4 

## 📝 PR 유형

> 해당하는 유형에 'x'로 체크해주세요.

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] 사전 협의 된 페이지 별 url 주소에 맞도록 라우팅 설정 (`createBrowserRouter` API 적용)
- [x] 코드 스플리팅을 위한 `React.lazy` 적용
- [x] `src/constants/router.ts` - url 주소 상수 구조화

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 하나의 `Router.tsx` 컴포넌트 파일에 모든 도메인에 대한 라우트 코드를 작성했습니다.
  해당 파일 내부적으로는 라우트 별로 분리하여 적용(ex: `authRoutes, shopRoutes ...`)하긴 했는데,
  이것도 파일 단위로 분리하는게 좋을 지 고민이 되네요 🤔.
  프로젝트가 크지 않아 모든 라우트 경로를 하나의 파일에서 보는게 더 효율적인 것 같아서 이렇게 구현했습니다.
  추후에 분리할 필요성이 발생한다면 그 때 분리해도 될 것 같다고도 생각이 듭니다. 😅