### PR TITLE
[feat] API 로직 구현

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-VITE_API_ENDPOINT = https://bootcamp-api.codeit.kr/api/14-1/the-julge

--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_ENDPOINT = https://bootcamp-api.codeit.kr/api/14-1/the-julge

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/src/apis/client/interceptors.tsx
+++ b/src/apis/client/interceptors.tsx
@@ -1,0 +1,13 @@
+import type { InternalAxiosRequestConfig } from "axios";
+
+export const requestInterceptor = (
+  config: InternalAxiosRequestConfig,
+): InternalAxiosRequestConfig => {
+  const token = localStorage.getItem("token") ?? "";
+
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+
+  return config;
+};

--- a/src/apis/client/interceptors.tsx
+++ b/src/apis/client/interceptors.tsx
@@ -3,7 +3,7 @@ import type { InternalAxiosRequestConfig } from "axios";
 export const requestInterceptor = (
   config: InternalAxiosRequestConfig,
 ): InternalAxiosRequestConfig => {
-  const token = localStorage.getItem("token") ?? "";
+  const token: string | null = localStorage.getItem("token");
 
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;

--- a/src/apis/client/requestor.tsx
+++ b/src/apis/client/requestor.tsx
@@ -11,8 +11,8 @@ const requestor: AxiosInstance = axios.create({
   },
 });
 
-requestor.interceptors.request.use(requestInterceptor, (error: AxiosError) =>
-  Promise.reject(error),
-);
+requestor.interceptors.request.use(requestInterceptor, (error: AxiosError) => {
+  return Promise.reject(error);
+});
 
 export default requestor;

--- a/src/apis/client/requestor.tsx
+++ b/src/apis/client/requestor.tsx
@@ -1,0 +1,18 @@
+import axios, { AxiosError, AxiosInstance } from "axios";
+
+import { requestInterceptor } from "./interceptors";
+
+const requestor: AxiosInstance = axios.create({
+  baseURL: (import.meta.env.VITE_API_ENDPOINT as string).trim(),
+  timeout: 60000,
+  headers: {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  },
+});
+
+requestor.interceptors.request.use(requestInterceptor, (error: AxiosError) =>
+  Promise.reject(error),
+);
+
+export default requestor;

--- a/src/apis/services/alertService.tsx
+++ b/src/apis/services/alertService.tsx
@@ -1,25 +1,23 @@
 import type { AxiosResponse } from "axios";
-import { AlertListResponse, AlertResponse } from "src/types";
+import { AlertListResponse, AlertReadListResponse } from "src/types";
 
 import requestor from "../client/requestor";
 
-class AlertService {
-  getAlerts(
-    userId: string,
-    offset?: number,
-    limit?: number,
-  ): Promise<AxiosResponse<AlertListResponse>> {
-    return requestor.get(`/users/${userId}/alerts`, {
-      params: { offset, limit },
-    });
-  }
+/* 유저의 알림 목록 조회 */
+export const getAlerts = (
+  userId: string,
+  offset: number = 0,
+  limit?: number,
+): Promise<AxiosResponse<AlertListResponse>> => {
+  return requestor.get(`/users/${userId}/alerts`, {
+    params: { offset, limit },
+  });
+};
 
-  putAlert(
-    userId: string,
-    alertId: string,
-  ): Promise<AxiosResponse<AlertResponse>> {
-    return requestor.put(`/users/${userId}/alerts/${alertId}`);
-  }
-}
-
-export default new AlertService();
+/* 알림 읽음 처리 */
+export const putAlert = (
+  userId: string,
+  alertId: string,
+): Promise<AxiosResponse<AlertReadListResponse>> => {
+  return requestor.put(`/users/${userId}/alerts/${alertId}`);
+};

--- a/src/apis/services/alertService.tsx
+++ b/src/apis/services/alertService.tsx
@@ -1,0 +1,25 @@
+import type { AxiosResponse } from "axios";
+import { AlertListResponse, AlertResponse } from "src/types";
+
+import requestor from "../client/requestor";
+
+class AlertService {
+  getAlerts(
+    userId: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<AxiosResponse<AlertListResponse>> {
+    return requestor.get(`/users/${userId}/alerts`, {
+      params: { offset, limit },
+    });
+  }
+
+  putAlert(
+    userId: string,
+    alertId: string,
+  ): Promise<AxiosResponse<AlertResponse>> {
+    return requestor.put(`/users/${userId}/alerts/${alertId}`);
+  }
+}
+
+export default new AlertService();

--- a/src/apis/services/applicationService.tsx
+++ b/src/apis/services/applicationService.tsx
@@ -1,0 +1,52 @@
+import type { AxiosResponse } from "axios";
+import {
+  ApplicationListResponse,
+  ApplicationResponse,
+  ApplicationStatus,
+} from "src/types";
+
+import requestor from "../client/requestor";
+
+class ApplicationService {
+  getShopApplications(
+    shopId: string,
+    noticeId: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<AxiosResponse<ApplicationListResponse>> {
+    return requestor.get(`/shops/${shopId}/notices/${noticeId}/applications`, {
+      params: { offset, limit },
+    });
+  }
+
+  postApplication(
+    shopId: string,
+    noticeId: string,
+  ): Promise<AxiosResponse<ApplicationResponse>> {
+    return requestor.post(`/shops/${shopId}/notices/${noticeId}/applications`);
+  }
+
+  putApplication(
+    shopId: string,
+    noticeId: string,
+    applicationId: string,
+    status: Exclude<ApplicationStatus, "pending">,
+  ): Promise<AxiosResponse<ApplicationResponse>> {
+    return requestor.put(
+      `/shops/${shopId}/notices/${noticeId}/applications/${applicationId}`,
+      { status },
+    );
+  }
+
+  getUserApplications(
+    userId: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<AxiosResponse<ApplicationListResponse>> {
+    return requestor.get(`/users/${userId}/applications`, {
+      params: { offset, limit },
+    });
+  }
+}
+
+export default new ApplicationService();

--- a/src/apis/services/applicationService.tsx
+++ b/src/apis/services/applicationService.tsx
@@ -3,50 +3,51 @@ import {
   ApplicationListResponse,
   ApplicationResponse,
   ApplicationStatus,
+  UserApplicationListResponse,
 } from "src/types";
 
 import requestor from "../client/requestor";
 
-class ApplicationService {
-  getShopApplications(
-    shopId: string,
-    noticeId: string,
-    offset?: number,
-    limit?: number,
-  ): Promise<AxiosResponse<ApplicationListResponse>> {
-    return requestor.get(`/shops/${shopId}/notices/${noticeId}/applications`, {
-      params: { offset, limit },
-    });
-  }
+/* 가게의 특정 공고의 지원 목록 조회 */
+export const getShopApplications = (
+  shopId: string,
+  noticeId: string,
+  offset?: number,
+  limit?: number,
+): Promise<AxiosResponse<ApplicationListResponse>> => {
+  return requestor.get(`/shops/${shopId}/notices/${noticeId}/applications`, {
+    params: { offset, limit },
+  });
+};
 
-  postApplication(
-    shopId: string,
-    noticeId: string,
-  ): Promise<AxiosResponse<ApplicationResponse>> {
-    return requestor.post(`/shops/${shopId}/notices/${noticeId}/applications`);
-  }
+/* 가게의 특정 공고 지원 등록 */
+export const postApplication = (
+  shopId: string,
+  noticeId: string,
+): Promise<AxiosResponse<ApplicationResponse>> => {
+  return requestor.post(`/shops/${shopId}/notices/${noticeId}/applications`);
+};
 
-  putApplication(
-    shopId: string,
-    noticeId: string,
-    applicationId: string,
-    status: Exclude<ApplicationStatus, "pending">,
-  ): Promise<AxiosResponse<ApplicationResponse>> {
-    return requestor.put(
-      `/shops/${shopId}/notices/${noticeId}/applications/${applicationId}`,
-      { status },
-    );
-  }
+/* 가게의 특정 공고 지원 승인, 거절 또는 취소소 */
+export const putApplication = (
+  shopId: string,
+  noticeId: string,
+  applicationId: string,
+  status: Exclude<ApplicationStatus, "pending">,
+): Promise<AxiosResponse<ApplicationResponse>> => {
+  return requestor.put(
+    `/shops/${shopId}/notices/${noticeId}/applications/${applicationId}`,
+    { status },
+  );
+};
 
-  getUserApplications(
-    userId: string,
-    offset?: number,
-    limit?: number,
-  ): Promise<AxiosResponse<ApplicationListResponse>> {
-    return requestor.get(`/users/${userId}/applications`, {
-      params: { offset, limit },
-    });
-  }
-}
-
-export default new ApplicationService();
+/* 유저의 지원 목록 조회 */
+export const getUserApplications = (
+  userId: string,
+  offset?: number,
+  limit?: number,
+): Promise<AxiosResponse<UserApplicationListResponse>> => {
+  return requestor.get(`/users/${userId}/applications`, {
+    params: { offset, limit },
+  });
+};

--- a/src/apis/services/authenticationService.tsx
+++ b/src/apis/services/authenticationService.tsx
@@ -1,0 +1,47 @@
+import type { AxiosResponse } from "axios";
+import type { UserItem } from "src/types";
+import { ApiWrapper } from "src/types";
+
+import requestor from "../client/requestor";
+
+interface LoginItem {
+  token: string;
+  user: ApiWrapper<UserItem>;
+}
+
+export type LoginRequest = { email: string; password: string };
+export type LoginResponse = ApiWrapper<LoginItem>;
+
+class AuthenticationService {
+  async postAuthentication(
+    payload: LoginRequest,
+  ): Promise<AxiosResponse<LoginResponse>> {
+    const res = await requestor.post<LoginResponse>("/token", payload);
+
+    const token = res.data.item.token;
+    const user = res.data.item.user.item;
+
+    localStorage.setItem("token", token);
+    localStorage.setItem("user", JSON.stringify(user));
+
+    return res;
+  }
+
+  logout() {
+    localStorage.removeItem("token");
+    localStorage.removeItem("user");
+  }
+
+  getToken() {
+    return localStorage.getItem("token");
+  }
+  isAuthenticated() {
+    return Boolean(this.getToken());
+  }
+  getUser(): UserItem | null {
+    const raw = localStorage.getItem("user");
+    return raw ? (JSON.parse(raw) as UserItem) : null;
+  }
+}
+
+export default new AuthenticationService();

--- a/src/apis/services/authenticationService.tsx
+++ b/src/apis/services/authenticationService.tsx
@@ -1,47 +1,44 @@
 import type { AxiosResponse } from "axios";
-import type { UserItem } from "src/types";
+import type { ApiWithHref, UserItem } from "src/types";
 import { ApiWrapper } from "src/types";
 
 import requestor from "../client/requestor";
 
 interface LoginItem {
   token: string;
-  user: ApiWrapper<UserItem>;
+  user: ApiWithHref<UserItem>;
 }
 
 export type LoginRequest = { email: string; password: string };
 export type LoginResponse = ApiWrapper<LoginItem>;
 
-class AuthenticationService {
-  async postAuthentication(
-    payload: LoginRequest,
-  ): Promise<AxiosResponse<LoginResponse>> {
-    const res = await requestor.post<LoginResponse>("/token", payload);
+/* 로그인 */
+export const postAuthentication = async (
+  payload: LoginRequest,
+): Promise<AxiosResponse<LoginResponse>> => {
+  const res = await requestor.post<LoginResponse>("/token", payload);
 
-    const token = res.data.item.token;
-    const user = res.data.item.user.item;
+  const token = res.data.item.token;
+  const user = res.data.item.user.item;
 
-    localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify(user));
+  localStorage.setItem("token", token);
+  localStorage.setItem("user", JSON.stringify(user));
 
-    return res;
-  }
+  return res;
+};
 
-  logout() {
-    localStorage.removeItem("token");
-    localStorage.removeItem("user");
-  }
+/* 로그아웃 */
+export const logout = () => {
+  localStorage.removeItem("token");
+  localStorage.removeItem("user");
+};
 
-  getToken() {
-    return localStorage.getItem("token");
-  }
-  isAuthenticated() {
-    return Boolean(this.getToken());
-  }
-  getUser(): UserItem | null {
-    const raw = localStorage.getItem("user");
-    return raw ? (JSON.parse(raw) as UserItem) : null;
-  }
-}
+/* 토큰 반환 */
+export const getToken = () => {
+  return localStorage.getItem("token");
+};
 
-export default new AuthenticationService();
+/* 인증 여부 확인 */
+export const isAuthenticated = () => {
+  return Boolean(getToken());
+};

--- a/src/apis/services/imageService.tsx
+++ b/src/apis/services/imageService.tsx
@@ -1,0 +1,37 @@
+import axios, { AxiosResponse } from "axios";
+import { ApiWrapper } from "src/types";
+
+import requestor from "../client/requestor";
+
+interface PresignedItem {
+  url: string;
+}
+type PresignedResponse = ApiWrapper<PresignedItem>;
+
+class ImageService {
+  async postImage(name: string): Promise<string> {
+    const res: AxiosResponse<PresignedResponse> = await requestor.post(
+      "/images",
+      { name },
+    );
+    return res.data.item.url;
+  }
+
+  async putImage(
+    presignedURL: string,
+    file: File | Blob,
+  ): Promise<AxiosResponse<void>> {
+    return axios.put(presignedURL, file, {
+      headers: { "Content-Type": file.type || "application/octet-stream" },
+    });
+  }
+
+  getPublicURL(presignedURL: string) {
+    return presignedURL.split("?")[0];
+  }
+  getImage(publicURL: string): Promise<AxiosResponse<Blob>> {
+    return axios.get(publicURL, { responseType: "blob" });
+  }
+}
+
+export default new ImageService();

--- a/src/apis/services/imageService.tsx
+++ b/src/apis/services/imageService.tsx
@@ -8,30 +8,31 @@ interface PresignedItem {
 }
 type PresignedResponse = ApiWrapper<PresignedItem>;
 
-class ImageService {
-  async postImage(name: string): Promise<string> {
-    const res: AxiosResponse<PresignedResponse> = await requestor.post(
-      "/images",
-      { name },
-    );
-    return res.data.item.url;
-  }
+/* Presigned URL 생성 */
+export const postImage = async (name: string): Promise<string> => {
+  const res: AxiosResponse<PresignedResponse> = await requestor.post(
+    "/images",
+    { name },
+  );
+  return res.data.item.url;
+};
 
-  async putImage(
-    presignedURL: string,
-    file: File | Blob,
-  ): Promise<AxiosResponse<void>> {
-    return axios.put(presignedURL, file, {
-      headers: { "Content-Type": file.type || "application/octet-stream" },
-    });
-  }
+/* S3로 이미지 업로드 */
+export const putImage = async (
+  presignedURL: string,
+  file: File | Blob,
+): Promise<AxiosResponse<void>> => {
+  return axios.put(presignedURL, file, {
+    headers: { "Content-Type": file.type || "application/octet-stream" },
+  });
+};
 
-  getPublicURL(presignedURL: string) {
-    return presignedURL.split("?")[0];
-  }
-  getImage(publicURL: string): Promise<AxiosResponse<Blob>> {
-    return axios.get(publicURL, { responseType: "blob" });
-  }
-}
+/* Presigned URL 조회 */
+export const getPublicURL = (presignedURL: string) => {
+  return presignedURL.split("?")[0];
+};
 
-export default new ImageService();
+/* 이미지 조회 */
+export const getImage = (publicURL: string): Promise<AxiosResponse<Blob>> => {
+  return axios.get(publicURL, { responseType: "blob" });
+};

--- a/src/apis/services/noticeService.tsx
+++ b/src/apis/services/noticeService.tsx
@@ -1,57 +1,52 @@
 import type { AxiosResponse } from "axios";
 import {
-  NoticeListResponse,
   NoticeResponse,
-  SortKey,
   NoticePayload,
+  GetNoticesParams,
+  NoticeListResponseWithoutUserApplication,
 } from "src/types";
 
 import requestor from "../client/requestor";
 
-class NoticeService {
-  getNotices(params?: {
-    offset?: number;
-    limit?: number;
-    address?: string;
-    keyword?: string;
-    startsAtGte?: string;
-    hourlyPayGte?: number;
-    sort?: SortKey;
-  }): Promise<AxiosResponse<NoticeListResponse>> {
-    return requestor.get("/notices", { params });
-  }
+/* 공고 조회 */
+export const getNotices = (
+  params?: GetNoticesParams,
+): Promise<AxiosResponse<NoticeListResponseWithoutUserApplication>> => {
+  return requestor.get("/notices", { params });
+};
 
-  getShopNotices(
-    shopId: string,
-    offset?: number,
-    limit?: number,
-  ): Promise<AxiosResponse<NoticeListResponse>> {
-    return requestor.get(`/shops/${shopId}/notices`, {
-      params: { offset, limit },
-    });
-  }
+/* 가게의 공고 목록 조회 */
+export const getShopNotices = (
+  shopId: string,
+  offset?: number,
+  limit?: number,
+): Promise<AxiosResponse<NoticeListResponseWithoutUserApplication>> => {
+  return requestor.get(`/shops/${shopId}/notices`, {
+    params: { offset, limit },
+  });
+};
 
-  postNotice(
-    shopId: string,
-    payload: NoticePayload,
-  ): Promise<AxiosResponse<NoticeResponse>> {
-    return requestor.post(`/shops/${shopId}/notices`, payload);
-  }
+/* 가게 공고 등록 */
+export const postNotice = (
+  shopId: string,
+  payload: NoticePayload,
+): Promise<AxiosResponse<NoticeResponse>> => {
+  return requestor.post(`/shops/${shopId}/notices`, payload);
+};
 
-  getNotice(
-    shopId: string,
-    noticeId: string,
-  ): Promise<AxiosResponse<NoticeResponse>> {
-    return requestor.get(`/shops/${shopId}/notices/${noticeId}`);
-  }
+/* 가게의 특정 공고 조회 */
+export const getNotice = (
+  shopId: string,
+  noticeId: string,
+): Promise<AxiosResponse<NoticeResponse>> => {
+  return requestor.get(`/shops/${shopId}/notices/${noticeId}`);
+};
 
-  putNotice(
-    shopId: string,
-    noticeId: string,
-    payload: NoticePayload,
-  ): Promise<AxiosResponse<NoticeResponse>> {
-    return requestor.put(`/shops/${shopId}/notices/${noticeId}`, payload);
-  }
-}
-
-export default new NoticeService();
+/* 가게의 특정 공고 수정 */
+export const putNotice = (
+  shopId: string,
+  noticeId: string,
+  payload: NoticePayload,
+): Promise<AxiosResponse<NoticeResponse>> => {
+  return requestor.put(`/shops/${shopId}/notices/${noticeId}`, payload);
+};

--- a/src/apis/services/noticeService.tsx
+++ b/src/apis/services/noticeService.tsx
@@ -1,0 +1,57 @@
+import type { AxiosResponse } from "axios";
+import {
+  NoticeListResponse,
+  NoticeResponse,
+  SortKey,
+  NoticePayload,
+} from "src/types";
+
+import requestor from "../client/requestor";
+
+class NoticeService {
+  getNotices(params?: {
+    offset?: number;
+    limit?: number;
+    address?: string;
+    keyword?: string;
+    startsAtGte?: string;
+    hourlyPayGte?: number;
+    sort?: SortKey;
+  }): Promise<AxiosResponse<NoticeListResponse>> {
+    return requestor.get("/notices", { params });
+  }
+
+  getShopNotices(
+    shopId: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<AxiosResponse<NoticeListResponse>> {
+    return requestor.get(`/shops/${shopId}/notices`, {
+      params: { offset, limit },
+    });
+  }
+
+  postNotice(
+    shopId: string,
+    payload: NoticePayload,
+  ): Promise<AxiosResponse<NoticeResponse>> {
+    return requestor.post(`/shops/${shopId}/notices`, payload);
+  }
+
+  getNotice(
+    shopId: string,
+    noticeId: string,
+  ): Promise<AxiosResponse<NoticeResponse>> {
+    return requestor.get(`/shops/${shopId}/notices/${noticeId}`);
+  }
+
+  putNotice(
+    shopId: string,
+    noticeId: string,
+    payload: NoticePayload,
+  ): Promise<AxiosResponse<NoticeResponse>> {
+    return requestor.put(`/shops/${shopId}/notices/${noticeId}`, payload);
+  }
+}
+
+export default new NoticeService();

--- a/src/apis/services/shopService.tsx
+++ b/src/apis/services/shopService.tsx
@@ -1,0 +1,23 @@
+import type { AxiosResponse } from "axios";
+import { ShopPayload, ShopResponse } from "src/types";
+
+import requestor from "../client/requestor";
+
+class ShopService {
+  postShop(payload: ShopPayload): Promise<AxiosResponse<ShopResponse>> {
+    return requestor.post("/shops", payload);
+  }
+
+  getShop(shopId: string): Promise<AxiosResponse<ShopResponse>> {
+    return requestor.get(`/shops/${shopId}`);
+  }
+
+  putShop(
+    shopId: string,
+    payload: ShopPayload,
+  ): Promise<AxiosResponse<ShopResponse>> {
+    return requestor.put(`/shops/${shopId}`, payload);
+  }
+}
+
+export default new ShopService();

--- a/src/apis/services/shopService.tsx
+++ b/src/apis/services/shopService.tsx
@@ -3,21 +3,24 @@ import { ShopPayload, ShopResponse } from "src/types";
 
 import requestor from "../client/requestor";
 
-class ShopService {
-  postShop(payload: ShopPayload): Promise<AxiosResponse<ShopResponse>> {
-    return requestor.post("/shops", payload);
-  }
+/* 가게 등록 */
+export const postShop = (
+  payload: ShopPayload,
+): Promise<AxiosResponse<ShopResponse>> => {
+  return requestor.post("/shops", payload);
+};
 
-  getShop(shopId: string): Promise<AxiosResponse<ShopResponse>> {
-    return requestor.get(`/shops/${shopId}`);
-  }
+/* 가게 정보 조회 */
+export const getShop = (
+  shopId: string,
+): Promise<AxiosResponse<ShopResponse>> => {
+  return requestor.get(`/shops/${shopId}`);
+};
 
-  putShop(
-    shopId: string,
-    payload: ShopPayload,
-  ): Promise<AxiosResponse<ShopResponse>> {
-    return requestor.put(`/shops/${shopId}`, payload);
-  }
-}
-
-export default new ShopService();
+/* 가게 정보 수정 */
+export const putShop = (
+  shopId: string,
+  payload: ShopPayload,
+): Promise<AxiosResponse<ShopResponse>> => {
+  return requestor.put(`/shops/${shopId}`, payload);
+};

--- a/src/apis/services/userService.tsx
+++ b/src/apis/services/userService.tsx
@@ -8,21 +8,24 @@ import {
 
 import requestor from "../client/requestor";
 
-class UserService {
-  postUser(payload: SignupPayload): Promise<AxiosResponse<SignupResponse>> {
-    return requestor.post("/users", payload);
-  }
+/* 회원가입 */
+export const postUser = (
+  payload: SignupPayload,
+): Promise<AxiosResponse<SignupResponse>> => {
+  return requestor.post("/users", payload);
+};
 
-  getUser(userId: string): Promise<AxiosResponse<UserResponse>> {
-    return requestor.get(`/users/${userId}`);
-  }
+/* 내 정보 조회 */
+export const getUser = (
+  userId: string,
+): Promise<AxiosResponse<UserResponse>> => {
+  return requestor.get(`/users/${userId}`);
+};
 
-  putUser(
-    userId: string,
-    payload: UpdateUserPayload,
-  ): Promise<AxiosResponse<UserResponse>> {
-    return requestor.put(`/users/${userId}`, payload);
-  }
-}
-
-export default new UserService();
+/* 내 정보 수정 */
+export const putUser = (
+  userId: string,
+  payload: UpdateUserPayload,
+): Promise<AxiosResponse<UserResponse>> => {
+  return requestor.put(`/users/${userId}`, payload);
+};

--- a/src/apis/services/userService.tsx
+++ b/src/apis/services/userService.tsx
@@ -1,0 +1,28 @@
+import type { AxiosResponse } from "axios";
+import {
+  SignupPayload,
+  SignupResponse,
+  UserResponse,
+  UpdateUserPayload,
+} from "src/types";
+
+import requestor from "../client/requestor";
+
+class UserService {
+  postUser(payload: SignupPayload): Promise<AxiosResponse<SignupResponse>> {
+    return requestor.post("/users", payload);
+  }
+
+  getUser(userId: string): Promise<AxiosResponse<UserResponse>> {
+    return requestor.get(`/users/${userId}`);
+  }
+
+  putUser(
+    userId: string,
+    payload: UpdateUserPayload,
+  ): Promise<AxiosResponse<UserResponse>> {
+    return requestor.put(`/users/${userId}`, payload);
+  }
+}
+
+export default new UserService();

--- a/src/types/alert.ts
+++ b/src/types/alert.ts
@@ -1,0 +1,24 @@
+import type { ApplicationStatus } from "./application";
+import type { ApiWrapper, ApiPaged } from "./common";
+import type { NoticeSummary } from "./notice";
+import type { ShopSummary } from "./shop";
+
+export type AlertResult = "accepted" | "rejected";
+
+export interface ApplicationMini {
+  id: string;
+  status: Exclude<ApplicationStatus, "canceled">;
+}
+
+export interface AlertItem {
+  id: string;
+  createdAt: string;
+  result: AlertResult;
+  read: boolean;
+  application: ApiWrapper<ApplicationMini>;
+  shop: ApiWrapper<ShopSummary>;
+  notice: ApiWrapper<NoticeSummary>;
+}
+
+export type AlertResponse = ApiWrapper<AlertItem>;
+export type AlertListResponse = ApiPaged<AlertItem>;

--- a/src/types/alert.ts
+++ b/src/types/alert.ts
@@ -1,5 +1,5 @@
 import type { ApplicationStatus } from "./application";
-import type { ApiWrapper, ApiPaged } from "./common";
+import type { ApiWrapper, ApiPaged, ApiWithHref, LinkItem } from "./common";
 import type { NoticeSummary } from "./notice";
 import type { ShopSummary } from "./shop";
 
@@ -15,10 +15,16 @@ export interface AlertItem {
   createdAt: string;
   result: AlertResult;
   read: boolean;
-  application: ApiWrapper<ApplicationMini>;
-  shop: ApiWrapper<ShopSummary>;
-  notice: ApiWrapper<NoticeSummary>;
+  application: ApiWithHref<ApplicationMini>;
+  shop: ApiWithHref<ShopSummary>;
+  notice: ApiWithHref<NoticeSummary>;
 }
 
 export type AlertResponse = ApiWrapper<AlertItem>;
 export type AlertListResponse = ApiPaged<AlertItem>;
+export interface AlertReadListResponse {
+  offset: number;
+  limit: number;
+  items: ApiWrapper<AlertItem>[];
+  links: LinkItem[];
+}

--- a/src/types/application.ts
+++ b/src/types/application.ts
@@ -1,4 +1,4 @@
-import type { ApiWrapper, ApiPaged } from "./common";
+import type { ApiWrapper, ApiPaged, ApiWithHref } from "./common";
 import type { NoticeSummary } from "./notice";
 import type { ShopSummary } from "./shop";
 import type { UserSummary } from "./user";
@@ -13,10 +13,14 @@ export interface ApplicationItem {
   id: string;
   status: ApplicationStatus;
   createdAt: string;
-  user: ApiWrapper<UserSummary>;
-  shop: ApiWrapper<ShopSummary>;
-  notice: ApiWrapper<NoticeSummary>;
+  user: ApiWithHref<UserSummary>;
+  shop: ApiWithHref<ShopSummary>;
+  notice: ApiWithHref<NoticeSummary>;
 }
+
+export type UserApplicationList = Omit<ApplicationItem, "user">;
 
 export type ApplicationResponse = ApiWrapper<ApplicationItem>;
 export type ApplicationListResponse = ApiPaged<ApplicationItem>;
+
+export type UserApplicationListResponse = ApiPaged<UserApplicationList>;

--- a/src/types/application.ts
+++ b/src/types/application.ts
@@ -1,0 +1,22 @@
+import type { ApiWrapper, ApiPaged } from "./common";
+import type { NoticeSummary } from "./notice";
+import type { ShopSummary } from "./shop";
+import type { UserSummary } from "./user";
+
+export type ApplicationStatus =
+  | "pending"
+  | "accepted"
+  | "rejected"
+  | "canceled";
+
+export interface ApplicationItem {
+  id: string;
+  status: ApplicationStatus;
+  createdAt: string;
+  user: ApiWrapper<UserSummary>;
+  shop: ApiWrapper<ShopSummary>;
+  notice: ApiWrapper<NoticeSummary>;
+}
+
+export type ApplicationResponse = ApiWrapper<ApplicationItem>;
+export type ApplicationListResponse = ApiPaged<ApplicationItem>;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,6 +1,18 @@
+export interface LinkItem {
+  rel: string;
+  description: string;
+  method: string;
+  href: string;
+}
+
 export interface ApiWrapper<T> {
   item: T;
-  links: unknown[];
+  links: LinkItem[];
+}
+
+export interface ApiWithHref<T> {
+  item: T;
+  href: string;
 }
 
 export interface ApiPaged<T> {
@@ -9,7 +21,7 @@ export interface ApiPaged<T> {
   count: number;
   hasNext: boolean;
   items: ApiWrapper<T>[];
-  links: unknown[];
+  links: LinkItem[];
 }
 
 export const SeoulDistricts = [

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,54 @@
+export interface ApiWrapper<T> {
+  item: T;
+  links: unknown[];
+}
+
+export interface ApiPaged<T> {
+  offset: number;
+  limit: number;
+  count: number;
+  hasNext: boolean;
+  items: ApiWrapper<T>[];
+  links: unknown[];
+}
+
+export const SeoulDistricts = [
+  "서울시 종로구",
+  "서울시 중구",
+  "서울시 용산구",
+  "서울시 성동구",
+  "서울시 광진구",
+  "서울시 동대문구",
+  "서울시 중랑구",
+  "서울시 성북구",
+  "서울시 강북구",
+  "서울시 도봉구",
+  "서울시 노원구",
+  "서울시 은평구",
+  "서울시 서대문구",
+  "서울시 마포구",
+  "서울시 양천구",
+  "서울시 강서구",
+  "서울시 구로구",
+  "서울시 금천구",
+  "서울시 영등포구",
+  "서울시 동작구",
+  "서울시 관악구",
+  "서울시 서초구",
+  "서울시 강남구",
+  "서울시 송파구",
+  "서울시 강동구",
+] as const;
+export type SeoulDistrict = (typeof SeoulDistricts)[number];
+
+export const ShopCategories = [
+  "한식",
+  "중식",
+  "일식",
+  "양식",
+  "분식",
+  "카페",
+  "편의점",
+  "기타",
+] as const;
+export type ShopCategory = (typeof ShopCategories)[number];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,6 @@
+export * from "./common";
+export * from "./user";
+export * from "./shop";
+export * from "./notice";
+export * from "./application";
+export * from "./alert";

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -1,7 +1,16 @@
-import type { ApiPaged, ApiWrapper } from "./common";
+import type { ApiPaged, ApiWithHref, ApiWrapper } from "./common";
 import type { ShopSummary } from "./shop";
 
-export type SortKey = "time" | "pay" | "hour" | "shop";
+export type SortKey =
+  | "time" /* 마감임박순 */
+  | "pay" /* 시급많은순 */
+  | "hour" /* 시간적은순 */
+  | "shop"; /* 가나다순 */
+
+export interface NoticeListMeta {
+  address: string[];
+  keyword?: string;
+}
 
 export interface NoticeItem {
   id: string;
@@ -10,7 +19,7 @@ export interface NoticeItem {
   workhour: number;
   description: string;
   closed: boolean;
-  shop?: ApiWrapper<ShopSummary>;
+  shop?: ApiWithHref<ShopSummary>;
   currentUserApplication?: {
     item: {
       id: string;
@@ -18,6 +27,16 @@ export interface NoticeItem {
       createdAt: string;
     };
   };
+}
+
+export interface GetNoticesParams {
+  offset?: number;
+  limit?: number;
+  address?: string;
+  keyword?: string;
+  startsAtGte?: string;
+  hourlyPayGte?: number;
+  sort?: SortKey;
 }
 
 export interface NoticePayload {
@@ -34,3 +53,11 @@ export type NoticeSummary = Pick<
 
 export type NoticeResponse = ApiWrapper<NoticeItem>;
 export type NoticeListResponse = ApiPaged<NoticeItem>;
+export type NoticeWithoutUserApplication = Omit<
+  NoticeItem,
+  "currentUserApplication"
+>;
+
+export interface NoticeListResponseWithoutUserApplication
+  extends ApiPaged<NoticeWithoutUserApplication>,
+    NoticeListMeta {}

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -1,0 +1,36 @@
+import type { ApiPaged, ApiWrapper } from "./common";
+import type { ShopSummary } from "./shop";
+
+export type SortKey = "time" | "pay" | "hour" | "shop";
+
+export interface NoticeItem {
+  id: string;
+  hourlyPay: number;
+  startsAt: string;
+  workhour: number;
+  description: string;
+  closed: boolean;
+  shop?: ApiWrapper<ShopSummary>;
+  currentUserApplication?: {
+    item: {
+      id: string;
+      status: "pending" | "accepted" | "rejected" | "canceled";
+      createdAt: string;
+    };
+  };
+}
+
+export interface NoticePayload {
+  hourlyPay: number;
+  startsAt: string;
+  workhour: number;
+  description: string;
+}
+
+export type NoticeSummary = Pick<
+  NoticeItem,
+  "id" | "hourlyPay" | "description" | "startsAt" | "workhour" | "closed"
+>;
+
+export type NoticeResponse = ApiWrapper<NoticeItem>;
+export type NoticeListResponse = ApiPaged<NoticeItem>;

--- a/src/types/shop.ts
+++ b/src/types/shop.ts
@@ -1,0 +1,38 @@
+import type { ApiWrapper, SeoulDistrict, ShopCategory } from "./common";
+import type { UserSummary } from "./user";
+
+export interface ShopItem {
+  id: string;
+  name: string;
+  category: ShopCategory;
+  address1: SeoulDistrict;
+  address2: string;
+  description: string;
+  imageUrl: string;
+  originalHourlyPay: number;
+  user?: ApiWrapper<UserSummary>;
+}
+
+export interface ShopPayload {
+  name: string;
+  category: ShopCategory;
+  address1: SeoulDistrict;
+  address2: string;
+  description: string;
+  imageUrl: string;
+  originalHourlyPay: number;
+}
+
+export type ShopSummary = Pick<
+  ShopItem,
+  | "id"
+  | "name"
+  | "category"
+  | "address1"
+  | "address2"
+  | "description"
+  | "imageUrl"
+  | "originalHourlyPay"
+>;
+
+export type ShopResponse = ApiWrapper<ShopItem>;

--- a/src/types/shop.ts
+++ b/src/types/shop.ts
@@ -1,7 +1,12 @@
-import type { ApiWrapper, SeoulDistrict, ShopCategory } from "./common";
+import type {
+  ApiWithHref,
+  ApiWrapper,
+  SeoulDistrict,
+  ShopCategory,
+} from "./common";
 import type { UserSummary } from "./user";
 
-export interface ShopItem {
+export interface ShopSummary {
   id: string;
   name: string;
   category: ShopCategory;
@@ -10,8 +15,9 @@ export interface ShopItem {
   description: string;
   imageUrl: string;
   originalHourlyPay: number;
-  user?: ApiWrapper<UserSummary>;
 }
+
+export type ShopItem = ShopSummary & { user?: ApiWithHref<UserSummary> };
 
 export interface ShopPayload {
   name: string;
@@ -22,17 +28,5 @@ export interface ShopPayload {
   imageUrl: string;
   originalHourlyPay: number;
 }
-
-export type ShopSummary = Pick<
-  ShopItem,
-  | "id"
-  | "name"
-  | "category"
-  | "address1"
-  | "address2"
-  | "description"
-  | "imageUrl"
-  | "originalHourlyPay"
->;
 
 export type ShopResponse = ApiWrapper<ShopItem>;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,5 +1,6 @@
 import type { ApiWrapper } from "./common";
 import type { SeoulDistrict } from "./common";
+import { ShopSummary } from "./shop";
 
 export type UserType = "employee" | "employer";
 
@@ -11,6 +12,7 @@ export interface UserItem {
   phone?: string;
   address?: SeoulDistrict;
   bio?: string;
+  shop?: ApiWrapper<ShopSummary> | null;
 }
 
 export type UserSummary = Pick<

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,37 @@
+import type { ApiWrapper } from "./common";
+import type { SeoulDistrict } from "./common";
+
+export type UserType = "employee" | "employer";
+
+export interface UserItem {
+  id: string;
+  email: string;
+  type: UserType;
+  name?: string;
+  phone?: string;
+  address?: SeoulDistrict;
+  bio?: string;
+}
+
+export type UserSummary = Pick<
+  UserItem,
+  "id" | "email" | "type" | "name" | "phone" | "address" | "bio"
+>;
+
+export interface SignupPayload {
+  email: string;
+  password: string;
+  type: UserType;
+}
+
+export interface UpdateUserPayload {
+  name?: string;
+  phone?: string;
+  address?: SeoulDistrict;
+  bio?: string;
+}
+
+export type UserResponse = ApiWrapper<UserItem>;
+export type SignupResponse = ApiWrapper<
+  Pick<UserItem, "id" | "email" | "type">
+>;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
Closes #13 

## 📝 PR 유형

> 해당하는 유형에 'x'로 체크해주세요.

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
api 로직 구현 완료하였습니다. 테스트 진행 결과 모두 문제 없이 잘 작동했습니다. 테스트 코드가 필요하시다면 알려주세요!

- `types` 폴더에 `common`, `alert`, `application`, `notice`, `shop`, `user`로 ts 파일 각각 만들어 api 구현에 사용된 type들 저장해두었습니다. `types/index.ts`에서 한 번에 export하고 있습니다.

- `client/interceptors.tsx`는 `localStorage`에 저장된 JWT 토큰을 꺼내서 `Authorization` 헤더에 자동으로 붙여주는 역할을 합니다.
- `client/requestor.tsx`는 `axios.create()`로 공통 `baseURL`, 타임아웃, 기본 헤더를 설정한 커스텀 axios 인스턴스를 생성하고 있습니다. 이를 위해 `.env` 파일을 작성하였습니다. 위에서 만들었던 `requestorInterceptor`를 연결해서 인증 헤더를 자동으로 주입합니다.
- `alertService.tsx`, `applicationService.tsx`, `authenticationService.tsx`, `imageService.tsx`, `noticeService.tsx`, `shopService.tsx`, `userService.tsx`는 각각 알림, 지원, 인증, 이미지, 공고, 가게, 유저 관련 api 호출을 모아 둔 파일입니다. API 명세서를 보고 작성하였습니다.

각각의 로직함수명은 HTTP 메서드 접두사를 사용해 작성했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
api에 사용되는 타입들을 types 폴더에 저장해두었는데, apis 폴더에 types 폴더를 새로 만들어 api에 사용되는 type들은 따로 사용하는 게 좋을지 여쭙고자 합니다..!!
