### PR TITLE
[feat] Table 컴포넌트 구현

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "postinstall": "node scripts/setup-git-hooks.cjs",
-    "prepare": "husky && husky install"
+    "prepare": "husky"
   },
   "lint-staged": {
     "**/*.{js,jsx}": [

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,0 +1,108 @@
+import {
+  HTMLAttributes,
+  ReactNode,
+  TableHTMLAttributes,
+  TdHTMLAttributes,
+} from "react";
+
+import { cn } from "@/utils/cn";
+
+interface TableProps<T> extends TableHTMLAttributes<HTMLTableElement> {
+  data: T[];
+  headRow: () => ReactNode;
+  bodyRow: (params: T) => ReactNode;
+  footerRow?: () => ReactNode;
+}
+
+function Table<T>({
+  data,
+  className,
+  headRow,
+  bodyRow,
+  footerRow,
+  ...props
+}: TableProps<T>) {
+  return (
+    <div className="rounded-lg border-[1px] border-gray-200 text-black overflow-hidden">
+      {/* ───── 스크롤이 필요한 영역 ───── */}
+      <div className="overflow-x-auto">
+        <table
+          className={cn(
+            "table-fixed min-w-full text-left border-collapse",
+            className,
+          )}
+          {...props}
+        >
+          <thead className="bg-red-50">{headRow()}</thead>
+          <tbody className="bg-white">{data.map(bodyRow)}</tbody>
+        </table>
+      </div>
+
+      {/* ──── 스크롤과 무관한 하단 영역 ───── */}
+      {footerRow && (
+        <table className="w-full border-collapse">
+          <tbody>{footerRow()}</tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+interface TrProps extends HTMLAttributes<HTMLTableRowElement> {
+  showLastBottomBorder?: boolean;
+}
+
+function Tr({ children, className, showLastBottomBorder, ...props }: TrProps) {
+  const tableRowClassName = cn(
+    showLastBottomBorder ? "border-b-[1px]" : "not-last:border-b-[1px]",
+    "border-gray-20",
+    className,
+  );
+
+  return (
+    <tr className={tableRowClassName} {...props}>
+      {children}
+    </tr>
+  );
+}
+
+function Th({
+  children,
+  className,
+  ...props
+}: TdHTMLAttributes<HTMLTableCellElement>) {
+  const thClassName = cn(
+    "px-3.5 py-3 text-sm font-normal",
+    "first:sticky left-0 border-gray-20 z-10 bg-red-50",
+    className,
+  );
+
+  return (
+    <th className={thClassName} {...props}>
+      {children}
+    </th>
+  );
+}
+
+interface TdProps extends TdHTMLAttributes<HTMLTableCellElement> {
+  noSticky?: boolean;
+}
+
+function Td({ children, className, noSticky, ...props }: TdProps) {
+  const tdClassName = cn(
+    "px-3.5 py-3 break-words whitespace-normal",
+    noSticky ? "" : "first:sticky left-0 z-10 bg-white first:whitespace-nowrap",
+    className,
+  );
+  return (
+    <td className={tdClassName} {...props}>
+      {children}
+    </td>
+  );
+}
+
+Table.Tr = Tr;
+Table.Th = Th;
+Table.Td = Td;
+
+export default Table;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

Closes #35 

## 📝 PR 유형

> 해당하는 유형에 'x'로 체크해주세요.

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] `Table` 공통 컴포넌트 구현
- [x] Wiki `Table` 컴포넌트 페이지 작성

자세한 사항은 Wiki [`Table` 컴포넌트](https://github.com/CodeitPart3/thejulge/wiki/Table) 페이지에서 확인 부탁드려요! 😄

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 렌더링 할 데이터셋을 배열형태로 전달받아 `bottomRow` props에서 한 행에 대한 형태를 구체적으로 전달하여 렌더링하는 방식으로 구현해봤습니다. 좀 더 좋은 방식이나, 또는 현재 방식으로도 잘 활용될 수 있을 지 다른 분들의 의견이 궁금합니다. 😅
